### PR TITLE
Snooze nightlight

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ include (ValaPrecompile)
 vala_precompile (VALA_C ${CMAKE_PROJECT_NAME}
   Indicator.vala
   Widgets/PopoverWidget.vala
+  Widgets/RevealerSwitch.vala
   Services/ColorInterface.vala
   ${CMAKE_CURRENT_BINARY_DIR}/config.vala
 PACKAGES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ include (ValaPrecompile)
 vala_precompile (VALA_C ${CMAKE_PROJECT_NAME}
   Indicator.vala
   Widgets/PopoverWidget.vala
+  Services/ColorInterface.vala
   ${CMAKE_CURRENT_BINARY_DIR}/config.vala
 PACKAGES
   gio-2.0

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -45,14 +45,20 @@ public class Nightlight.Indicator : Wingpanel.Indicator {
             indicator_icon = new Wingpanel.Widgets.OverlayIcon (ENABLED_ICON_NAME);
             indicator_icon.button_press_event.connect ((e) => {
                 if (e.button == Gdk.BUTTON_MIDDLE) {
-                    settings.set_boolean ("night-light-enabled", !settings.get_boolean ("night-light-enabled"));
+                    NightLight.Manager.get_instance ().toggle_snooze ();
                     return Gdk.EVENT_STOP;
                 }
 
                 return Gdk.EVENT_PROPAGATE;
             });
 
-            settings.bind ("night-light-enabled", this, "nightlight-state", GLib.SettingsBindFlags.GET);
+            NightLight.Manager.get_instance ().snooze_changed.connect ((value) => {
+                nightlight_state = !value;
+                popover_widget.snoozed = value;
+            });
+
+            nightlight_state = !NightLight.Manager.get_instance ().snoozed;
+            settings.bind ("night-light-enabled", this, "visible", GLib.SettingsBindFlags.GET);
         }
 
         return indicator_icon;

--- a/src/Services/ColorInterface.vala
+++ b/src/Services/ColorInterface.vala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+
+[DBus (name="org.gnome.SettingsDaemon.Color")]
+public interface NightLight.ColorInterface : Object {
+    public abstract bool disabled_until_tomorrow { get; set; }
+}
+
+public class NightLight.Manager : Object {
+    public signal void snooze_changed (bool value);
+
+    private NightLight.ColorInterface adapter;
+
+    public bool snoozed {
+        get {
+            return adapter.disabled_until_tomorrow;
+        } set {
+            adapter.disabled_until_tomorrow = value;
+            snooze_changed (value);
+        }
+    }
+
+    static NightLight.Manager? instance = null;
+    public static Manager get_instance () {
+        if (instance == null) {
+            instance = new Manager ();
+        }
+
+        return instance;
+    }
+
+    private Manager () {}
+
+    construct {
+        try {
+            adapter = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.SettingsDaemon.Color", "/org/gnome/SettingsDaemon/Color", DBusProxyFlags.NONE);
+        } catch (Error e) {
+            warning ("Could not connect to color settings: %s", e.message);
+        }
+    }
+
+    public void toggle_snooze () {
+        snoozed = !snoozed;
+    }
+}

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -21,7 +21,7 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
     public unowned Nightlight.Indicator indicator { get; construct set; }
     public unowned Settings settings { get; construct set; }
 
-    private Wingpanel.Widgets.Switch toggle_switch;
+    private NightLight.Widgets.Switch toggle_switch;
     private Gtk.Grid scale_grid;
     private Gtk.Image image;
     private Gtk.Scale temp_scale;
@@ -29,7 +29,7 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
     public bool snoozed {
         set {
             scale_grid.sensitive = !value;
-            toggle_switch.set_active (value);
+            toggle_switch.active = value;
 
             if (value) {
                 image.icon_name = "night-light-disabled-symbolic";
@@ -52,8 +52,7 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
     construct {
         orientation = Gtk.Orientation.VERTICAL;
 
-        toggle_switch = new Wingpanel.Widgets.Switch (_("Snooze Night Light"));
-        toggle_switch.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        toggle_switch = new NightLight.Widgets.Switch (_("Snooze Night Light"), _("Disabled until tomorrow"));
 
         image = new Gtk.Image ();
         image.pixel_size = 48;

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -26,14 +26,15 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
     private Gtk.Image image;
     private Gtk.Scale temp_scale;
 
-    public bool active {
+    public bool snoozed {
         set {
-            scale_grid.sensitive = value;
+            scale_grid.sensitive = !value;
+            toggle_switch.set_active (value);
 
             if (value) {
-                image.icon_name = "night-light-symbolic";
-            } else {
                 image.icon_name = "night-light-disabled-symbolic";
+            } else {
+                image.icon_name = "night-light-symbolic";
             }
          }
     }
@@ -51,7 +52,7 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
     construct {
         orientation = Gtk.Orientation.VERTICAL;
 
-        toggle_switch = new Wingpanel.Widgets.Switch (_("Night Light"));
+        toggle_switch = new Wingpanel.Widgets.Switch (_("Snooze Night Light"));
         toggle_switch.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
         image = new Gtk.Image ();
@@ -81,8 +82,10 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
         add (new Wingpanel.Widgets.Separator ());
         add (settings_button);
 
-        settings.bind ("night-light-enabled", toggle_switch.get_switch (), "active", GLib.SettingsBindFlags.DEFAULT);
-        settings.bind ("night-light-enabled", this, "active", GLib.SettingsBindFlags.GET);
+        snoozed = NightLight.Manager.get_instance ().snoozed;
+
+        toggle_switch.get_switch ().bind_property ("active", NightLight.Manager.get_instance (), "snoozed", GLib.BindingFlags.DEFAULT);
+        toggle_switch.get_switch ().bind_property ("active", this, "active", GLib.BindingFlags.DEFAULT);
         settings.bind ("night-light-temperature", this, "temperature", GLib.SettingsBindFlags.GET);
 
         temp_scale.value_changed.connect (() => {

--- a/src/Widgets/RevealerSwitch.vala
+++ b/src/Widgets/RevealerSwitch.vala
@@ -24,26 +24,44 @@ public class NightLight.Widgets.Switch : Wingpanel.Widgets.Container {
     private Gtk.Switch button_switch;
     private Gtk.Revealer subtitle_revealer;
 
+    private const string SWITCH_CSS = """
+        .compact-switch-labels label {
+            padding-bottom: 0;
+            padding-top: 0;
+        }
+    """;
+
     public bool active {
         get {
-            return button_switch.get_active ();
+            return button_switch.active;
         } set {
-            button_switch.set_active (value);
+            button_switch.active = value;
             subtitle_revealer.reveal_child = value;
             switched ();
         }
     }
 
     public Switch (string caption, string secondary, bool active = false) {
-        button_label = create_label_for_caption (caption);
-        button_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        button_label = new Gtk.Label (caption);
+        button_label.halign = Gtk.Align.START;
         button_label.valign = Gtk.Align.END;
+        button_label.margin_start = 6;
+        button_label.margin_end = 6;
+        button_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
-        var small_label = create_label_for_caption (secondary, true);
-        small_label.valign = Gtk.Align.START;
-        small_label.sensitive = false;
+        var small_label = new Gtk.Label ("<small>%s</small>".printf (Markup.escape_text (secondary)));
+        small_label.use_markup = true;
+        small_label.halign = Gtk.Align.START;
+        small_label.margin_start = 6;
+        small_label.margin_end = 6;
+        small_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-        button_switch = create_switch (active);
+        button_switch = new Gtk.Switch ();
+        button_switch.active = active;
+        button_switch.halign = Gtk.Align.END;
+        button_switch.hexpand = true;
+        button_switch.margin = 3;
+        button_switch.margin_end = 6;
         button_switch.valign = Gtk.Align.CENTER;
 
         subtitle_revealer = new Gtk.Revealer ();
@@ -52,10 +70,19 @@ public class NightLight.Widgets.Switch : Wingpanel.Widgets.Container {
         content_widget.attach (button_label, 0, 0, 1, 1);
         content_widget.attach (subtitle_revealer, 0, 1, 1, 1);
         content_widget.attach (button_switch, 1, 0, 1, 2);
+        content_widget.get_style_context ().add_class ("compact-switch-labels");
+
+        var provider = new Gtk.CssProvider ();
+        try {
+            provider.load_from_data (SWITCH_CSS, SWITCH_CSS.length);
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        } catch (Error e) {
+            critical (e.message);
+        }
 
         clicked.connect (() => {
             active = true;
-            toggle_switch ();
+            button_switch.activate ();
         });
 
         button_switch.bind_property ("active", this, "active", GLib.BindingFlags.DEFAULT);
@@ -63,36 +90,5 @@ public class NightLight.Widgets.Switch : Wingpanel.Widgets.Container {
 
     public Gtk.Switch get_switch () {
         return button_switch;
-    }
-
-    public void toggle_switch () {
-        button_switch.activate ();
-    }
-
-    private Gtk.Label create_label_for_caption (string caption, bool small = false) {
-        Gtk.Label label_widget;
-
-        if (small) {
-            label_widget = new Gtk.Label ("<small>%s</small>".printf (Markup.escape_text (caption)));
-        } else {
-            label_widget = new Gtk.Label (Markup.escape_text (caption));
-        }
-
-        label_widget.use_markup = true;
-        label_widget.halign = Gtk.Align.START;
-        label_widget.margin_start = 6;
-        label_widget.margin_end = 10;
-
-        return label_widget;
-    }
-
-    private Gtk.Switch create_switch (bool active) {
-        var switch_widget = new Gtk.Switch ();
-        switch_widget.active = active;
-        switch_widget.halign = Gtk.Align.END;
-        switch_widget.margin_end = 6;
-        switch_widget.hexpand = true;
-
-        return switch_widget;
     }
 }

--- a/src/Widgets/RevealerSwitch.vala
+++ b/src/Widgets/RevealerSwitch.vala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2011-2015 Wingpanel Developers (http://launchpad.net/wingpanel)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+public class NightLight.Widgets.Switch : Wingpanel.Widgets.Container {
+    public new signal void switched ();
+
+    private Gtk.Label button_label;
+    private Gtk.Switch button_switch;
+    private Gtk.Revealer subtitle_revealer;
+
+    public bool active {
+        get {
+            return button_switch.get_active ();
+        } set {
+            button_switch.set_active (value);
+            subtitle_revealer.reveal_child = value;
+            switched ();
+        }
+    }
+
+    public Switch (string caption, string secondary, bool active = false) {
+        button_label = create_label_for_caption (caption);
+        button_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
+        button_label.valign = Gtk.Align.END;
+
+        var small_label = create_label_for_caption (secondary, true);
+        small_label.valign = Gtk.Align.START;
+        small_label.sensitive = false;
+
+        button_switch = create_switch (active);
+        button_switch.valign = Gtk.Align.CENTER;
+
+        subtitle_revealer = new Gtk.Revealer ();
+        subtitle_revealer.add (small_label);
+
+        content_widget.attach (button_label, 0, 0, 1, 1);
+        content_widget.attach (subtitle_revealer, 0, 1, 1, 1);
+        content_widget.attach (button_switch, 1, 0, 1, 2);
+
+        clicked.connect (() => {
+            active = true;
+            toggle_switch ();
+        });
+
+        button_switch.bind_property ("active", this, "active", GLib.BindingFlags.DEFAULT);
+    }
+
+    public Gtk.Switch get_switch () {
+        return button_switch;
+    }
+
+    public void toggle_switch () {
+        button_switch.activate ();
+    }
+
+    private Gtk.Label create_label_for_caption (string caption, bool small = false) {
+        Gtk.Label label_widget;
+
+        if (small) {
+            label_widget = new Gtk.Label ("<small>%s</small>".printf (Markup.escape_text (caption)));
+        } else {
+            label_widget = new Gtk.Label (Markup.escape_text (caption));
+        }
+
+        label_widget.use_markup = true;
+        label_widget.halign = Gtk.Align.START;
+        label_widget.margin_start = 6;
+        label_widget.margin_end = 10;
+
+        return label_widget;
+    }
+
+    private Gtk.Switch create_switch (bool active) {
+        var switch_widget = new Gtk.Switch ();
+        switch_widget.active = active;
+        switch_widget.halign = Gtk.Align.END;
+        switch_widget.margin_end = 6;
+        switch_widget.hexpand = true;
+
+        return switch_widget;
+    }
+}

--- a/src/Widgets/RevealerSwitch.vala
+++ b/src/Widgets/RevealerSwitch.vala
@@ -65,6 +65,7 @@ public class NightLight.Widgets.Switch : Wingpanel.Widgets.Container {
         button_switch.valign = Gtk.Align.CENTER;
 
         subtitle_revealer = new Gtk.Revealer ();
+        subtitle_revealer.valign = Gtk.Align.CENTER;
         subtitle_revealer.add (small_label);
 
         content_widget.attach (button_label, 0, 0, 1, 1);


### PR DESCRIPTION
Use Snooze instead of active to control the Night Light from the indicator

Todo: 

- [x] ~Change to use `org.freedesktop.DBus.Properties` as the actual interface doesn't send signals (and an external change wouldn't get caught)~ 
- [x] Change back to the normal interface, and use the "native" signal (https://github.com/elementary/switchboard-plug-bluetooth/blob/master/src/Services/Manager.vala#L97)
- [x] Add the revealer label on the Switch

Fixes #9 