### PR TITLE
Recursive lookup of the settings

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -87,7 +87,7 @@ public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorMan
         return null;
     }
 
-    var interface_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.color", false);
+    var interface_settings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.color", true);
     if (interface_settings_schema == null || !interface_settings_schema.has_key ("night-light-enabled")) {
         debug ("No night-light schema found");
         return null;


### PR DESCRIPTION
For some reason, both the indicator and the plug stopped showing up on me due to the SettingsSchemaSource not finding the schema.

I've had this happen before, and setting the param to `true` fixes it 
https://valadoc.org/gio-2.0/GLib.SettingsSchemaSource.lookup.html