### PR TITLE
Show the indicator only when it's in use

### DIFF
--- a/src/Services/ColorInterface.vala
+++ b/src/Services/ColorInterface.vala
@@ -20,10 +20,12 @@
 [DBus (name="org.gnome.SettingsDaemon.Color")]
 public interface NightLight.ColorInterface : Object {
     public abstract bool disabled_until_tomorrow { get; set; }
+    public abstract bool night_light_active { get; }
 }
 
 public class NightLight.Manager : Object {
     public signal void snooze_changed (bool value);
+    public signal void active_changed (bool value);
 
     private NightLight.ColorInterface interface;
 
@@ -33,6 +35,12 @@ public class NightLight.Manager : Object {
         } set {
             interface.disabled_until_tomorrow = value;
             snooze_changed (value);
+        }
+    }
+
+    public bool active {
+        get {
+            return interface.night_light_active;
         }
     }
 
@@ -56,6 +64,12 @@ public class NightLight.Manager : Object {
 
                 if (snooze != null) {
                     snoozed = snooze.get_boolean ();
+                }
+
+                var _active = changed.lookup_value ("NightLightActive", new VariantType ("b"));
+
+                if (_active != null) {
+                    active_changed (_active.get_boolean ());
                 }
             });
         } catch (Error e) {

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -84,7 +84,6 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
         snoozed = NightLight.Manager.get_instance ().snoozed;
 
         toggle_switch.get_switch ().bind_property ("active", NightLight.Manager.get_instance (), "snoozed", GLib.BindingFlags.DEFAULT);
-        toggle_switch.get_switch ().bind_property ("active", this, "active", GLib.BindingFlags.DEFAULT);
         settings.bind ("night-light-temperature", this, "temperature", GLib.SettingsBindFlags.GET);
 
         temp_scale.value_changed.connect (() => {


### PR DESCRIPTION
On `org.gnome.SettingsDaemon.Color` theres a property called NightLightActive that appears to do what we want it to do. It's only set to true during "night-time" 

### Things to test:
- Does the indicator autohide if it's snoozed after the time is up? (see note 1)

### Notes:

- Moving the time manually doesn't seem to remove Snooze on my machine, and while Snooze is active it appears that the NightLightActive peroperty doesn't get updated properly (Upstream bug?)
- The reason why i didn't use show if shoozed || temperature < 6500 is because it appears that it sometimes stops on the 6490s (Another Upstream bug?). So using the NightLightActive property might be more reliable 

fixes #3 