### PR TITLE
Say disabled until sunrise when auto schedule

### DIFF
--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -26,6 +26,16 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
     private Gtk.Image image;
     private Gtk.Scale temp_scale;
 
+    public bool automatic_schedule {
+        set {
+            if (value) {
+                toggle_switch.secondary_label = _("Disabled until sunrise");
+            } else {
+                toggle_switch.secondary_label = _("Disabled until tomorrow");
+            }
+        }
+    }
+
     public bool snoozed {
         set {
             scale_grid.sensitive = !value;
@@ -33,12 +43,6 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
 
             if (value) {
                 image.icon_name = "night-light-disabled-symbolic";
-
-                if (settings.get_boolean ("night-light-schedule-automatic")) {
-                    toggle_switch.secondary_label = _("Disabled until sunrise");
-                } else {
-                    toggle_switch.secondary_label = _("Disabled until tomorrow");
-                }
             } else {
                 image.icon_name = "night-light-symbolic";
             }
@@ -92,6 +96,7 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
 
         toggle_switch.get_switch ().bind_property ("active", NightLight.Manager.get_instance (), "snoozed", GLib.BindingFlags.DEFAULT);
         settings.bind ("night-light-temperature", this, "temperature", GLib.SettingsBindFlags.GET);
+        settings.bind ("night-light-schedule-automatic", this, "automatic_schedule", GLib.SettingsBindFlags.GET);
 
         temp_scale.value_changed.connect (() => {
             settings.set_uint ("night-light-temperature", (uint) temp_scale.get_value ());

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -33,6 +33,12 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Grid {
 
             if (value) {
                 image.icon_name = "night-light-disabled-symbolic";
+
+                if (settings.get_boolean ("night-light-schedule-automatic")) {
+                    toggle_switch.secondary_label = _("Disabled until sunrise");
+                } else {
+                    toggle_switch.secondary_label = _("Disabled until tomorrow");
+                }
             } else {
                 image.icon_name = "night-light-symbolic";
             }

--- a/src/Widgets/RevealerSwitch.vala
+++ b/src/Widgets/RevealerSwitch.vala
@@ -21,6 +21,7 @@ public class NightLight.Widgets.Switch : Wingpanel.Widgets.Container {
     public new signal void switched ();
 
     private Gtk.Label button_label;
+    private Gtk.Label small_label;
     private Gtk.Switch button_switch;
     private Gtk.Revealer subtitle_revealer;
 
@@ -41,15 +42,21 @@ public class NightLight.Widgets.Switch : Wingpanel.Widgets.Container {
         }
     }
 
-    public Switch (string caption, string secondary, bool active = false) {
-        button_label = new Gtk.Label (caption);
+    public string secondary_label {
+        set {
+            small_label.label = "<small>%s</small>".printf (Markup.escape_text (value));
+        }
+    }
+
+    public Switch (string primary_label, string secondary_label, bool active = false) {
+        button_label = new Gtk.Label (primary_label);
         button_label.halign = Gtk.Align.START;
         button_label.valign = Gtk.Align.END;
         button_label.margin_start = 6;
         button_label.margin_end = 6;
         button_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
-        var small_label = new Gtk.Label ("<small>%s</small>".printf (Markup.escape_text (secondary)));
+        small_label = new Gtk.Label ("<small>%s</small>".printf (Markup.escape_text (secondary_label)));
         small_label.use_markup = true;
         small_label.halign = Gtk.Align.START;
         small_label.margin_start = 6;


### PR DESCRIPTION
Partial fix for #14 

This sets the secondary label to "Disabled until sunrise" when the night light schedule is set to automatic.

Also changes variable names in RevealerSwitch for clarity