### PR TITLE
Update POTFILES to fix build

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,4 +1,3 @@
 src/Indicator.vala
 src/Services/ColorInterface.vala
 src/Widgets/PopoverWidget.vala
-src/Widgets/RevealerSwitch.vala


### PR DESCRIPTION
This was missed in https://github.com/elementary/wingpanel-indicator-nightlight/pull/83 which was breaking builds.