### PR TITLE
Indicator: remove unnecessary construction args

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -88,8 +88,7 @@ public class Nightlight.Indicator : Wingpanel.Indicator {
 
     public override Gtk.Widget? get_widget () {
         if (popover_widget == null) {
-            var settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.color");
-            popover_widget = new Nightlight.Widgets.PopoverWidget (this, settings);
+            popover_widget = new Nightlight.Widgets.PopoverWidget ();
         }
 
         return popover_widget;

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -4,13 +4,11 @@
  */
 
 public class Nightlight.Widgets.PopoverWidget : Gtk.Box {
-    public unowned Nightlight.Indicator indicator { get; construct set; }
-    public unowned Settings settings { get; construct set; }
-
     private Granite.SwitchModelButton toggle_switch;
     private Gtk.Box scale_box;
     private Gtk.Image image;
     private Gtk.Scale temp_scale;
+    private Settings settings;
     private const int TEMP_CHANGE_DELAY_MS = 300;
 
     public bool automatic_schedule {
@@ -40,10 +38,6 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Box {
         set {
             temp_scale.set_value (value);
         }
-    }
-
-    public PopoverWidget (Nightlight.Indicator indicator, Settings settings) {
-        Object (indicator: indicator, settings: settings);
     }
 
     construct {
@@ -94,6 +88,8 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Box {
         snoozed = NightLight.Manager.get_instance ().snoozed;
 
         toggle_switch.bind_property ("active", NightLight.Manager.get_instance (), "snoozed", GLib.BindingFlags.DEFAULT);
+
+        settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.color");
         settings.bind ("night-light-temperature", this, "temperature", GLib.SettingsBindFlags.GET);
         settings.bind ("night-light-schedule-automatic", this, "automatic_schedule", GLib.SettingsBindFlags.GET);
 
@@ -125,7 +121,5 @@ public class Nightlight.Widgets.PopoverWidget : Gtk.Box {
         } catch (Error e) {
             warning ("Failed to open display settings: %s", e.message);
         }
-
-        indicator.close ();
     }
 }


### PR DESCRIPTION
* ModelButton closes the indicator so we don't need to hold a ref to the indicator here
* Move settings into PopoverWidget. It doesn't need to be instantiated outside of this class