### PR TITLE
Indicator: add css provider for screen

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -19,15 +19,14 @@
 
 public class Nightlight.Indicator : Wingpanel.Indicator {
     private Gtk.Spinner? indicator_icon = null;
-    private Gtk.StyleContext style_context;
     private Nightlight.Widgets.PopoverWidget? popover_widget = null;
 
     public bool nightlight_state {
         set {
             if (value) {
-                style_context.remove_class ("disabled");
+                indicator_icon.get_style_context ().remove_class ("disabled");
             } else {
-                style_context.add_class ("disabled");
+                indicator_icon.get_style_context ().add_class ("disabled");
             }
         }
     }
@@ -50,9 +49,13 @@ public class Nightlight.Indicator : Wingpanel.Indicator {
             var provider = new Gtk.CssProvider ();
             provider.load_from_resource ("io/elementary/wingpanel/nightlight/indicator.css");
 
-            style_context = indicator_icon.get_style_context ();
-            style_context.add_class ("night-light-icon");
-            style_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            Gtk.StyleContext.add_provider_for_screen (
+                Gdk.Screen.get_default (),
+                provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            );
+
+            indicator_icon.get_style_context ().add_class ("night-light-icon");
 
             indicator_icon.button_press_event.connect ((e) => {
                 if (e.button == Gdk.BUTTON_MIDDLE) {


### PR DESCRIPTION
Getting style context for a widget and adding a provider to a widget is deprecated.

* use `indicator_icon.get_style_context ().add_class` and `indicator_icon.get_style_context ().remove_class`. This will be replaced with `indicator_icon.add_css_class` and `indicator_icon.remove_css_class` in GTK4
* Add style provider to screen instead of to the indicator icon context